### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,12 @@
 setting.py
+
+# Created by https://www.gitignore.io/api/sass
+# Edit at https://www.gitignore.io/?templates=sass
+
+### Sass ###
+.sass-cache/
+*.css.map
+*.sass.map
+*.scss.map
+
+# End of https://www.gitignore.io/api/sass


### PR DESCRIPTION
¿Qué ha cambiado?
Agregamos al gitignore soporte para sass

- [ ] Frontend
- [ ] Backend
- [ x ] Configuración del server

# ¿Cómo puedo probar los cambios?
Por ejemplo los archivos *.sass.map ya no se suben al repo, ver el archivo .gitignore completo.
